### PR TITLE
docs: 教程与案例新增「在线改写」入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - ⚡ [QClaw + aiworkskills 一键运营公众号](https://mp.weixin.qq.com/s/xLUJBc2bbrJvgeAesbhsFA) · QClaw 组合案例
 - 🔑 [小龙虾的模型怎么选](https://mp.weixin.qq.com/s/u5e7FC-QAzXaMlq36RNIJg) · 写作与配图模型选型指南
 - 🚀 [从写作助手到 AI 运营员工：wechat-article-skills 进化之路](https://mp.weixin.qq.com/s/PRAE37gaEDF92gjwRBEOQg) · 项目演进历程
+- 🌐 [在线试用「改写」功能](https://socialistic.ai/zh/skill/aws-wechat-article-writing-317084?utm_source=github&utm_medium=readme&utm_campaign=wechat-article-skills&utm_content=tutorial-section) · 不装环境，贴段稿子直接体验网感改写
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - ⚡ [QClaw + aiworkskills 一键运营公众号](https://mp.weixin.qq.com/s/xLUJBc2bbrJvgeAesbhsFA) · QClaw 组合案例
 - 🔑 [小龙虾的模型怎么选](https://mp.weixin.qq.com/s/u5e7FC-QAzXaMlq36RNIJg) · 写作与配图模型选型指南
 - 🚀 [从写作助手到 AI 运营员工：wechat-article-skills 进化之路](https://mp.weixin.qq.com/s/PRAE37gaEDF92gjwRBEOQg) · 项目演进历程
-- 🌐 [在线试用「改写」功能](https://socialistic.ai/zh/skill/aws-wechat-article-writing-317084?utm_source=github&utm_medium=readme&utm_campaign=wechat-article-skills&utm_content=tutorial-section) · 不装环境，贴段稿子直接体验网感改写
+- 🌐 [在线试用「改写」功能](https://socialistic.ai/zh/skill/aws-wechat-article-writing-317084?utm_source=github&utm_medium=readme&utm_campaign=20260615-netfeel-meme-copy-skills&utm_content=tutorial-section) · 不装环境，贴段稿子直接体验网感改写
 
 ---
 


### PR DESCRIPTION
## Summary

- 在 README「📚 教程与案例」末尾新增一条「在线试用改写功能」链接，指向 [Socialistic 托管的 aws-wechat-article-writing 在线入口](https://socialistic.ai/zh/skill/aws-wechat-article-writing-317084)
- 读者不用装智能体、不用配 Key，贴段稿子说「改活泼点」就能直接体验改写
- 链接带 UTM 参数（`utm_source=github&utm_medium=readme&utm_campaign=20260615-netfeel-meme-copy-skills&utm_content=tutorial-section`），方便追踪从 README 过来的流量

🤖 Generated with [Claude Code](https://claude.com/claude-code)