### PR TITLE
fix: 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ IMAGE_MODEL_API_KEY=sk-...
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=aiworkskills/wechat-article-skills&type=Date)](https://star-history.com/#aiworkskills/wechat-article-skills&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=aiworkskills/wechat-article-skills&type=Date)](https://star-history.dera.page/#aiworkskills/wechat-article-skills&Date)
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -165,7 +165,7 @@ Full history in [CHANGELOG.md](CHANGELOG.md). Recent highlights:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=aiworkskills/wechat-article-skills&type=Date)](https://star-history.com/#aiworkskills/wechat-article-skills&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=aiworkskills/wechat-article-skills&type=Date)](https://star-history.dera.page/#aiworkskills/wechat-article-skills&Date)
 
 ---
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub stargazer API 限制已经损坏无法正常显示，这个改动将其迁移到 star-history.dera.page 替代数据源（无需 API token，同一域名同时服务前端与图表接口），并同步更新了 README_EN 英文版本。